### PR TITLE
[output] make a new CSV outputter to make an output that can be easily analyzed

### DIFF
--- a/source/CCM/CCM.csproj
+++ b/source/CCM/CCM.csproj
@@ -77,6 +77,7 @@
   <ItemGroup>
     <Compile Include="CCMOutputter.cs" />
     <Compile Include="ConsoleOutputter.cs" />
+    <Compile Include="CSVOutputter.cs" />
     <Compile Include="TabbedOutputter.cs" />
     <Compile Include="Driver.cs" />
     <Compile Include="ErrorInfo.cs" />

--- a/source/CCM/CCMOutputter.cs
+++ b/source/CCM/CCMOutputter.cs
@@ -10,6 +10,7 @@ namespace CCM
     public static string XmlOutputType = "XML";
     public static string TextOutputType = "Text";
     public static string TabbedOutputType = "Tabbed";
+    public static string CSVOutputType = "CSV";
 
     public abstract void Output(List<ccMetric> metrics, List<ErrorInfo> errors, bool verbose);
   }

--- a/source/CCM/CSVOutputter.cs
+++ b/source/CCM/CSVOutputter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CCMEngine;
+
+namespace CCM
+{
+  class CSVOutputter : CCMOutputter
+  {
+    public override void Output(List<ccMetric> metrics, List<ErrorInfo> errors, bool verbose)
+    {
+      if (metrics.Count() > 0)
+      {
+        Console.WriteLine("Method name,Complexity,Category,Filename,Start line,End line,SLoC");
+
+        metrics.ForEach(m =>
+          {
+            Console.WriteLine("\"{0}\",{1},{2},{3},{4},{5},{6}",
+              m.Unit, m.CCM, m.Classification, m.Filename, m.StartLineNumber, m.EndLineNumber,
+              (m.EndLineNumber - m.StartLineNumber));
+          }
+        );
+      }
+
+      if (verbose)
+        foreach (ErrorInfo error in errors)
+          Console.WriteLine("Error in file '{0}' : {1}", error.File, error.Message);
+    }
+
+  }
+}

--- a/source/CCM/Program.cs
+++ b/source/CCM/Program.cs
@@ -66,6 +66,9 @@ namespace CCM
       if (outputType.Equals(CCMOutputter.XmlOutputType, StringComparison.OrdinalIgnoreCase))
         return new XmlOutputter();
 
+      if (outputType.Equals(CCMOutputter.CSVOutputType, StringComparison.OrdinalIgnoreCase))
+        return new CSVOutputter();
+
       return new ConsoleOutputter();
     }
 


### PR DESCRIPTION
- add CSV outputter for easy analysis

Using the CCM tool on the large codebase that has some very large and complex functions, whilst the XML output is very useful and the console output tells you what you need, having a CSV output allows for analysis in tools such as excel without additional parsing of the request being required.
