### PR TITLE
Fix issue 8: error in line number

### DIFF
--- a/source/CCMEngine/LookAheadLangParser.cs
+++ b/source/CCMEngine/LookAheadLangParser.cs
@@ -102,7 +102,7 @@ namespace CCMEngine
             return PeekNextKeyword(0);
         }
 
-        public string MoveToNextLine()
+        public string MoveToNextLine(bool trimNewLine = true)
         {
             StringBuilder sb = new StringBuilder();
 
@@ -110,7 +110,7 @@ namespace CCMEngine
                 sb.Append(tok);
 
             this.tokens.Clear();
-            sb.Append(this.parser.MoveToNextLine());
+            sb.Append(this.parser.MoveToNextLine(trimNewLine));
 
             return sb.ToString();
         }

--- a/source/CCMEngine/LookAheadLangParser.cs
+++ b/source/CCMEngine/LookAheadLangParser.cs
@@ -102,7 +102,7 @@ namespace CCMEngine
             return PeekNextKeyword(0);
         }
 
-        public string MoveToNextLine(bool trimNewLine = true)
+        public string MoveToNextLine()
         {
             StringBuilder sb = new StringBuilder();
 
@@ -110,7 +110,7 @@ namespace CCMEngine
                 sb.Append(tok);
 
             this.tokens.Clear();
-            sb.Append(this.parser.MoveToNextLine(trimNewLine));
+            sb.Append(this.parser.MoveToNextLine());
 
             return sb.ToString();
         }

--- a/source/CCMEngine/LookAheadTokenParser.cs
+++ b/source/CCMEngine/LookAheadTokenParser.cs
@@ -168,7 +168,7 @@ namespace CCMEngine
       }
     }
 
-    public string MoveToNextLine(bool trimNewline = true)
+    public string MoveToNextLine()
     {
       StringBuilder sb = new StringBuilder();
       sb.Append(this.buffer.ToArray());
@@ -186,16 +186,7 @@ namespace CCMEngine
       {
       }
 
-            return sb.ToString();
-
-        if (trimNewline)
-        {
-            return sb.ToString().TrimEnd(new char[] { '\r', '\n' });
-        }
-        else
-        {
-            return sb.ToString();
-        }
+      return sb.ToString();
     }
 
     public string PeekNextToken()

--- a/source/CCMEngine/LookAheadTokenParser.cs
+++ b/source/CCMEngine/LookAheadTokenParser.cs
@@ -168,7 +168,7 @@ namespace CCMEngine
       }
     }
 
-    public string MoveToNextLine()
+    public string MoveToNextLine(bool trimNewline = true)
     {
       StringBuilder sb = new StringBuilder();
       sb.Append(this.buffer.ToArray());
@@ -186,7 +186,16 @@ namespace CCMEngine
       {
       }
 
-      return sb.ToString().TrimEnd(new char[] { '\r', '\n' });
+            return sb.ToString();
+
+        if (trimNewline)
+        {
+            return sb.ToString().TrimEnd(new char[] { '\r', '\n' });
+        }
+        else
+        {
+            return sb.ToString();
+        }
     }
 
     public string PeekNextToken()

--- a/source/CCMEngine/Preprocessor.cs
+++ b/source/CCMEngine/Preprocessor.cs
@@ -169,17 +169,15 @@ namespace CCMEngine
 
     private string MoveToNextLineSpaceOutput()
     {
-      string line = this.parser.MoveToNextLine(false);
+      string line = this.parser.MoveToNextLine();
 
-            foreach (char c in line)
-            {
-                if (c != '\n')
-                    this.sb.Append(" ");
-                else
-                    this.sb.Append(c);
-            }
-
-       //     this.sb.Append(System.Environment.NewLine);
+      foreach (char c in line)
+      {
+          if (c != '\n')
+              this.sb.Append(" ");
+          else
+              this.sb.Append(c);
+      }
 
       return line;
     }

--- a/source/CCMEngine/Preprocessor.cs
+++ b/source/CCMEngine/Preprocessor.cs
@@ -169,12 +169,18 @@ namespace CCMEngine
 
     private string MoveToNextLineSpaceOutput()
     {
-      string line = this.parser.MoveToNextLine();
+      string line = this.parser.MoveToNextLine(false);
 
-      foreach (char c in line)
-        this.sb.Append(" ");
+            foreach (char c in line)
+            {
+                if (c != '\n')
+                    this.sb.Append(" ");
+                else
+                    this.sb.Append(c);
+            }
 
-      this.sb.Append("\r\n");
+       //     this.sb.Append(System.Environment.NewLine);
+
       return line;
     }
 

--- a/source/CCMTests/LookAheadTokenParserTests.cs
+++ b/source/CCMTests/LookAheadTokenParserTests.cs
@@ -118,7 +118,7 @@ namespace CCMTests
       LookAheadTokenParser parser = new LookAheadTokenParser(TestUtil.GetTextStream(text), new string[] { }, false);
 
       Assert.AreEqual("This", parser.PeekNextToken());
-      Assert.AreEqual("This is a line \\ ", parser.MoveToNextLine());
+      Assert.AreEqual("This is a line \\ \r\n", parser.MoveToNextLine());
       Assert.AreEqual("And", parser.PeekNextToken());
     }
 

--- a/source/CCMTests/PreprocessorTests.cs
+++ b/source/CCMTests/PreprocessorTests.cs
@@ -581,7 +581,7 @@ namespace CCMTests
 
 
     [TestMethod]
-    public void Test()
+    public void TestCanConsumeCommentWithoutChangingLineCount()
     {
         string text = @"
 //

--- a/source/CCMTests/PreprocessorTests.cs
+++ b/source/CCMTests/PreprocessorTests.cs
@@ -90,6 +90,7 @@ namespace CCMTests
 
       Assert.AreEqual(true, Preprocessor.NextIsEndif(LookAheadLangParserFactory.CreateCppParser(TestUtil.GetTextStream(text))));
     }
+
     [TestMethod]
     public void IfDef1()
     {
@@ -98,9 +99,9 @@ namespace CCMTests
                     "#endif\r\n";
 
       string expect =
-                    "         \r\n" +
+                    "          \n" +
                     "the lazy brown fox \r\n" +
-                    "      \r\n";
+                    "       \n";
 
 
       Preprocessor preprocessor = new Preprocessor(TestUtil.GetTextStream(text));
@@ -330,7 +331,7 @@ namespace CCMTests
       Preprocessor preprocessor = new Preprocessor(TestUtil.GetTextStream(text));
       StreamReader result = preprocessor.Process();
 
-      Assert.AreEqual("   \r\ntext", result.ReadToEnd());
+      Assert.AreEqual("    \ntext", result.ReadToEnd());
     }
 
     [TestMethod]

--- a/source/CCMTests/PreprocessorTests.cs
+++ b/source/CCMTests/PreprocessorTests.cs
@@ -577,7 +577,27 @@ namespace CCMTests
 
       Assert.AreEqual("text", result.Trim());
       Assert.AreEqual(text.Length, result.Length);
-
     }
+
+
+    [TestMethod]
+    public void Test()
+    {
+        string text = @"
+//
+
+function B()
+{
+}
+";
+        Preprocessor preprocessor = new Preprocessor(TestUtil.GetTextStream(text));
+
+        StreamReader afterProcessing = TestUtil.GetTextStream(preprocessor.Process().ReadToEnd());
+        StreamReader orignal = TestUtil.GetTextStream(text);
+
+        Assert.AreEqual(TestUtil.GetNumLines(orignal), TestUtil.GetNumLines(afterProcessing));
+    }
+        
+
   }
 }

--- a/source/CCMTests/TestUtil.cs
+++ b/source/CCMTests/TestUtil.cs
@@ -15,6 +15,14 @@ namespace CCMTests
       return sr;
     }
 
-    
+    public static int GetNumLines(StreamReader reader)
+    {
+        int lines = 0;
+
+        while (null != reader.ReadLine())
+            lines++;
+
+        return lines;
+    }
   }
 }


### PR DESCRIPTION
Preprocessor would scale away trailing new lines after consuming comment lines, hence throwing the stream offset/line number counting off. 